### PR TITLE
Precision in JavaDoc

### DIFF
--- a/src/main/java/com/esotericsoftware/kryonet/Server.java
+++ b/src/main/java/com/esotericsoftware/kryonet/Server.java
@@ -546,6 +546,14 @@ public class Server implements EndPoint {
 			trace("kryonet", "Server thread stopped.");
 	}
 
+	/**
+	 * Starts a new thread that calls {@link #run()}.
+	 * Make sure you call a {@code bind} before starting your server.
+	 * 
+	 * @see #bind(int)
+	 * @see #bind(int, int)
+	 * @see #bind(InetSocketAddress, InetSocketAddress)
+	 */
 	@Override
 	public void start() {
 		new Thread(this, "Server").start();


### PR DESCRIPTION
Based on the latest documentation fix 

See: https://github.com/crykn/kryonet/commit/cbb26bb30cc8dce52e287e5a79abc0ec4824c086